### PR TITLE
Rename "fail" in Tree View

### DIFF
--- a/web/assets/js/prolog_bfs/classes/TreeView.js
+++ b/web/assets/js/prolog_bfs/classes/TreeView.js
@@ -171,7 +171,7 @@ class TreeView {
             }
             // query_node FAILED, has no children
             else if (current_query_node.failed()) {
-                nodes.push({ id: additional_node_counter, label: "failed! (No such rule)" });
+                nodes.push({ id: additional_node_counter, label: "no such rule" });
                 edges.push( {
                     from: current_query_node_id,
                     to: additional_node_counter,
@@ -209,7 +209,7 @@ class TreeView {
                             //Der Fassbender baum lässt manche failed nodes weg... Deshalb hier an jeder edge die rule line
                         nodes.push( { 
                             id: additional_node_counter, 
-                            label: "failed",
+                            label: "not unifiable",
                             color: {
                                 background: "lightgray",
                                 border: "gray"


### PR DESCRIPTION
"fail" was not quite clear and there was no distinction between the 
two cases, where a "fail" might occur.
1. "fail" on a query_node, where no matching rule was found
 => now called "no such rule"
2. "fail" on a var_binding_node => now called "not unifiable"