### PR TITLE
Allow catch tests in browser, cleanup cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ CMakeCache.txt
 build/*
 bfs
 CMakeLists.txt
+
+# this can be removed as soon as https://github.com/emscripten-core/emscripten/issues/9637#issuecomment-632742739 is fixed
+web/prolog_bfs.data 

--- a/CMakeLists.txt.wasm
+++ b/CMakeLists.txt.wasm
@@ -1,3 +1,22 @@
+# GENEREAL INFO
+# Compiler / Linker FLAG EXPLANATION
+# --bind enable embind
+# --emrun optimize for use with emrun (server to run the code)
+# DISABLE_EXCEPTION_CATCHING=0 to allow exceptions *within* the c++ code to be caught.
+#   Exceptions are disabled by default because of performance. We need them though.
+# USE_BOOST_HEADERS=1 automatically retrieve the boost headers and include them
+# MODULARIZE=1 prevent emscripten from polluting JS global scope. Put everything into EXPORT_NAME
+# EXPORT_NAME specify the name of the namespace for MODULARIZE
+# ALLOW_MEMORY_GROWTH Allow memory to grow to size defined by MAXIMUM_MEMORY
+# -O3 optimizations
+# preload-file: load normal files into .data file, so files can be used despite being in the browser
+
+# Use "SHELL:" to prevent de-duplication of the -s flags! See
+# https://stackoverflow.com/questions/60552844/how-do-i-migrate-from-compile-flags-to-target-compile-options-in-cmake/60553977#60553977
+
+###########
+# GENERAL #
+###########
 cmake_minimum_required(VERSION 3.13)
 project(prolog_bfs)
 
@@ -8,39 +27,93 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/build)
 
 set(CMAKE_CXX_STANDARD 17)
 
-# this is not required anymore because of -s USE_BOOST_HEADERS=1 flag
-#FIND_PACKAGE(Boost REQUIRED )
-#INCLUDE_DIRECTORIES( ${Boost_INCLUDE_DIR} )
-
-file(GLOB_RECURSE prolog_bfs_src
+# general sources we always need
+file(GLOB_RECURSE files_common
     "src/wasm/*"
     "src/wam/*.h"
     "src/wam/*.cpp"
 )
+list(REMOVE_ITEM files_common "${PROJECT_SOURCE_DIR}/src/wasm/test.cpp") # this is only used for test builds
 
-add_executable(prolog_bfs ${prolog_bfs_src})
+# sourced we only need for testing
+file(GLOB_RECURSE files_test
+    "test/*"
+)
+list(APPEND files_test "src/wasm/test.cpp") # because we removed it above
+
+#############
+# DEV BUILD #
+#############
+add_executable(prolog_bfs_dev ${files_common})
+
+# output name should always be prolog_bfs for wasm, so the .js file is always called the same way
+set_target_properties(prolog_bfs_dev PROPERTIES OUTPUT_NAME "prolog_bfs")
 
 #make include from src possible
-target_include_directories(prolog_bfs PRIVATE ${PROJECT_SOURCE_DIR}/src)
+target_include_directories(prolog_bfs_dev PRIVATE ${PROJECT_SOURCE_DIR}/src)
 
-# no need to mention boost libs anymore because of -s USE_BOOST_HEADERS=1
-TARGET_LINK_LIBRARIES( prolog_bfs LINK_PUBLIC )
+# compile options
+#target_compile_options(prolog_bfs_dev PUBLIC -O3) # faster compilation without optimization
+target_compile_options(prolog_bfs_dev PUBLIC "SHELL:-s USE_BOOST_HEADERS=1")
+target_compile_options(prolog_bfs_dev PUBLIC "SHELL:-s DISABLE_EXCEPTION_CATCHING=0")
 
-##########################
-# compile and link options
-##########################
+# link options
+#target_link_options(prolog_bfs_dev PUBLIC -O3) # faster compilation without optimization
+target_link_options(prolog_bfs_dev PUBLIC --bind)
+target_link_options(prolog_bfs_dev PUBLIC --emrun)
+target_link_options(prolog_bfs_dev PUBLIC "SHELL:-s USE_BOOST_HEADERS=1")
+target_link_options(prolog_bfs_dev PUBLIC "SHELL:-s DISABLE_EXCEPTION_CATCHING=0")
+target_link_options(prolog_bfs_dev PUBLIC "SHELL:-s MODULARIZE=1" "SHELL:-s EXPORT_NAME=\"'EmscriptenModule'\"")
+target_link_options(prolog_bfs_dev PUBLIC "SHELL:-s ALLOW_MEMORY_GROWTH=1" "SHELL:-s MAXIMUM_MEMORY=500MB")
 
-# FLAG EXPLANATION
-# --bind enable embind
-# --emrun optimize for use with emrun (server to run the code)
-# DISABLE_EXCEPTION_CATCHING=0 to allow exceptions *within* the c++ code to be caught.
-#   Exceptions are disabled by default because of performance. We need them though.
-# USE_BOOST_HEADERS=1 automatically retrieve the boost headers and include them
-# MODULARIZE=1 prevent emscripten from polluting JS global scope. Put everything into EXPORT_NAME
-# EXPORT_NAME specify the name of the namespace for MODULARIZE
-# ALLOW_MEMORY_GROWTH Allow memory to grow to size defined by MAXIMUM_MEMORY
 
-# Use "SHELL:" to prevent de-duplication of the -s flags! See https://stackoverflow.com/questions/60552844/how-do-i-migrate-from-compile-flags-to-target-compile-options-in-cmake/60553977#60553977
+##############
+# TEST BUILD #
+##############
+add_executable(prolog_bfs_test ${files_test} ${files_common})
 
-target_compile_options(prolog_bfs PUBLIC "SHELL:-s USE_BOOST_HEADERS=1" "SHELL:-s DISABLE_EXCEPTION_CATCHING=0")
-target_link_options(prolog_bfs PUBLIC --bind --emrun "SHELL:-s USE_BOOST_HEADERS=1" "SHELL:-s DISABLE_EXCEPTION_CATCHING=0" "SHELL:-s MODULARIZE=1" "SHELL:-s EXPORT_NAME=\"'EmscriptenModule'\"" "SHELL:-s ALLOW_MEMORY_GROWTH=1" "SHELL:-s MAXIMUM_MEMORY=500MB")
+# output name should always be prolog_bfs for wasm, so the .js file is always called the same way
+set_target_properties(prolog_bfs_test PROPERTIES OUTPUT_NAME "prolog_bfs")
+
+#make include from src possible
+target_include_directories(prolog_bfs_test PRIVATE ${PROJECT_SOURCE_DIR}/src)
+
+# compile options
+target_compile_options(prolog_bfs_test PUBLIC -O3) # test if optimizations don't break anything
+target_compile_options(prolog_bfs_test PUBLIC "SHELL:-s USE_BOOST_HEADERS=1")
+target_compile_options(prolog_bfs_test PUBLIC "SHELL:-s DISABLE_EXCEPTION_CATCHING=0")
+
+# link options
+target_link_options(prolog_bfs_test PUBLIC -O3) # test if optimizations don't break anything
+target_link_options(prolog_bfs_test PUBLIC --bind)
+target_link_options(prolog_bfs_test PUBLIC --emrun)
+target_link_options(prolog_bfs_test PUBLIC --preload-file test_src)
+target_link_options(prolog_bfs_test PUBLIC "SHELL:-s USE_BOOST_HEADERS=1")
+target_link_options(prolog_bfs_test PUBLIC "SHELL:-s DISABLE_EXCEPTION_CATCHING=0")
+target_link_options(prolog_bfs_test PUBLIC "SHELL:-s MODULARIZE=1" "SHELL:-s EXPORT_NAME=\"'EmscriptenModule'\"")
+target_link_options(prolog_bfs_test PUBLIC "SHELL:-s ALLOW_MEMORY_GROWTH=1" "SHELL:-s MAXIMUM_MEMORY=500MB")
+
+
+####################
+# PRODUCTION BUILD #
+####################
+add_executable(prolog_bfs_prod ${files_common})
+
+# output name should always be prolog_bfs for wasm, so the .js file is always called the same way
+set_target_properties(prolog_bfs_prod PROPERTIES OUTPUT_NAME "prolog_bfs")
+
+#make include from src possible
+target_include_directories(prolog_bfs_prod PRIVATE ${PROJECT_SOURCE_DIR}/src)
+
+# compile options
+target_compile_options(prolog_bfs_prod PUBLIC -O3)
+target_compile_options(prolog_bfs_prod PUBLIC "SHELL:-s USE_BOOST_HEADERS=1")
+target_compile_options(prolog_bfs_prod PUBLIC "SHELL:-s DISABLE_EXCEPTION_CATCHING=0")
+
+# link options
+target_link_options(prolog_bfs_prod PUBLIC -O3)
+target_link_options(prolog_bfs_prod PUBLIC --bind)
+target_link_options(prolog_bfs_prod PUBLIC "SHELL:-s USE_BOOST_HEADERS=1")
+target_link_options(prolog_bfs_prod PUBLIC "SHELL:-s DISABLE_EXCEPTION_CATCHING=0")
+target_link_options(prolog_bfs_prod PUBLIC "SHELL:-s MODULARIZE=1" "SHELL:-s EXPORT_NAME=\"'EmscriptenModule'\"")
+target_link_options(prolog_bfs_prod PUBLIC "SHELL:-s ALLOW_MEMORY_GROWTH=1" "SHELL:-s MAXIMUM_MEMORY=500MB")

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ git clone https://github.com/LhKipp/Prolog_BFS.git
 cd Prolog_BFS
 ./build_xxx.sh
 ```
-There are 2 different build scripts. "build_native" builds the cli applicationand "build_wasm" builds the WebAssembly files.
+There are 2 different build scripts. "build_native" builds the cli application and "build_wasm" builds the WebAssembly files.
 If you first build wasm, then native (or the other way around) make sure to delete the `CMakeCache.txt` file! Otherwise the build might fail.
 
 ## Building native

--- a/README.md
+++ b/README.md
@@ -2,22 +2,26 @@ A simple prolog breadth first search interpreter
 ================================================
 
 
-How to use it
--------------
+# How to use it
 Visit: https://askuri.github.io/PrologBFS/wasm/
 or build it from source.
 Suppose your executable is named "prolog_bfs",
 type "prolog_bfs program_file" and it will run.
 WebAssembly: run "start_server.sh" and go to http://localhost:8080/
 
-Install Instructions
---------------------
-# Prerequisites
-Boost.Program_options, Boost.Spirit, Boost.Phoenix
-Cmake version 3.13 or higher
-Compiler for C++ 17 or higher 
-Optional: Emsdk for building wasm files, version 1.39.10 or higher.
+#Install Instructions
+## Prerequisites
+Dependencies:
 
+* Boost.Program_options, Boost.Spirit, Boost.Phoenix
+* Cmake version 3.13 or higher
+* Compiler for C++ 17 or higher
+* Optional: Emsdk for building wasm files, version 1.39.10 or higher: https://emscripten.org/docs/getting_started/downloads.html#installation-instructions
+
+We develop on Ubuntu Linux. If you use windows or another OS, you might need to change
+the commands accordingly.
+
+## Install
 ```shell
 #Boost libraries
 sudo apt-get install libboost-all-dev
@@ -25,12 +29,26 @@ git clone https://github.com/LhKipp/Prolog_BFS.git
 cd Prolog_BFS
 ./build_xxx.sh
 ```
-There are 2 different build scripts. "build_native" builds the cli application and "build_wasm" builds the WebAssembly files.
-To build the wasm version further steps are required. Make sure to check the CMakeList.txt.wasm for further instructions.
+There are 2 different build scripts. "build_native" builds the cli applicationand "build_wasm" builds the WebAssembly files.
 If you first build wasm, then native (or the other way around) make sure to delete the `CMakeCache.txt` file! Otherwise the build might fail.
 
-Known Limitations
------------------
+## Building native
+Run `build_native.sh`. Currently, this only runs test cases.
+
+## Building for WebAssembly
+1. Source your emsdk environment
+2. Run `./build_wasm.sh <env>` where <env> can be either
+    * `dev` for a development build (fast compilation, no optimization, no test suite)
+    * `prod` for a production build (slow compilation, O3 optimization, no test suite) 
+    * `test` for a testing build (even slower compilation, O3 optimization, with test suite) 
+You may omit <env>, resulting in a dev build.
+
+### Running tests in the browser
+1. Run a test build
+2. Open your browser's javascript console while being on the prolog bfs site
+3. Run `runTests()` in the console. You should see the test output there
+
+# Known Limitations
 1. Only integer arithmetic is supported.
 2. Variables / constant names starting with an underscore are not supported. (This implies that a single "_" as a variable name is not supported)
 3. The only supported built in predicates are ==, \==, is/2 and append/3.
@@ -38,6 +56,5 @@ Known Limitations
 
 
 
-Contributors
-------------
+# Contributors
 - Martin Weber (https://github.com/askuri). Created the web version, tested the program, gave constructive feedback, found some bugs. Big thanks.

--- a/build_wasm.sh
+++ b/build_wasm.sh
@@ -7,8 +7,23 @@ cp CMakeLists.txt.wasm CMakeLists.txt
 
 # Be sure to have sourced the emsdk paths !!!
 emcmake cmake CMakeLists.txt
-emmake make prolog_bfs
+
+case $1 in
+    ""|"prod") echo "Running production built"
+            emmake make prolog_bfs_prod
+        ;;
+    "dev") echo "Running development built"
+            emmake make prolog_bfs_dev
+        ;;
+    "test") echo "Running testing built"
+            emmake make prolog_bfs_test
+        ;;
+    *|"help") echo "Allowed options: prod, dev, test. e.g. build_wasm.sh prod"
+esac
 
 # link the build output to the public directory so it can be accessed despite
 # not being in the document root of the server
 ln -sf ../build web/build
+
+# TODO this is because of a bug reported here: https://github.com/emscripten-core/emscripten/issues/9637#issuecomment-632742739
+ln -sf ../build/prolog_bfs.data web/prolog_bfs.data

--- a/src/wasm/test.cpp
+++ b/src/wasm/test.cpp
@@ -1,0 +1,25 @@
+#define CATCH_CONFIG_RUNNER
+#include <iostream>
+#include <emscripten/bind.h>
+#include "../../catch.hpp"
+#include <filesystem>
+#include <string>
+namespace fs = std::filesystem;
+
+using namespace emscripten;
+
+class Tests {
+public:
+    int runCatch() {
+        const char*test_args[] = {""};
+        return Catch::Session().run(2, test_args);
+    }
+};
+
+// Binding code
+EMSCRIPTEN_BINDINGS(Tests) {
+        class_<Tests>("Tests")
+                .constructor()
+                .function("runCatch", &Tests::runCatch);
+}
+

--- a/web/assets/js/prolog_bfs/main.js
+++ b/web/assets/js/prolog_bfs/main.js
@@ -76,6 +76,11 @@ function onRunClicked() {
     scrollResultsToBottom();
 }
 
+function runTests() {
+    // c++ unit tests
+    (new emscriptenModuleInstance.Tests()).runCatch();
+}
+
 /**
  * Automatically store the program code to prevent
  * data loss when the browser crashes.


### PR DESCRIPTION
This commit aims to allow running catch tests in the browser, which
puts them closer to the real world usage. This was done primarily
because we wanted to make sure that using -O3 optimizations in
emscripten won't break anything.

Along the way I also decided that it would be a good idea to update
our cmake file and separate it into different targets: dev, test and
prod. See readme to know what the difference is.

Summary:
This commit includes
1. testing through catch in the browser
2. improved cmake
3. O3 optimization for production builds