### PR TITLE
Always run make multithreaded

### DIFF
--- a/build_native.sh
+++ b/build_native.sh
@@ -11,4 +11,4 @@
 cp CMakeLists.txt.native CMakeLists.txt
 
 cmake CMakeLists.txt
-make prolog_bfs
+make prolog_bfs -j $(($(nproc) + 1)) 

--- a/build_wasm.sh
+++ b/build_wasm.sh
@@ -10,13 +10,13 @@ emcmake cmake CMakeLists.txt
 
 case $1 in
     "prod") echo "Running production built"
-            emmake make -j 12 prolog_bfs_prod
+            emmake make -j $(($(nproc) + 1)) prolog_bfs_prod
         ;;
     ""|"dev") echo "Running development built"
-            emmake make -j 12 prolog_bfs_dev
+            emmake make -j $(($(nproc) + 1)) prolog_bfs_dev
         ;;
     "test") echo "Running testing built"
-            emmake make -j 12 prolog_bfs_test
+            emmake make -j $(($(nproc) + 1)) prolog_bfs_test
         ;;
     *|"help") echo "Allowed options: prod, dev, test. e.g. build_wasm.sh prod"
 esac


### PR DESCRIPTION
Changes the jobs flag (`-j`) for make to use `nproc + 1`. This will enable make to use all
available processor cores, plus 1 for I/O.

This requires `GNU coreutils`, but it's the de-facto standard way of doing this. 

This speeds up compile times massively, especially for native builds which were `make`-ing on a single thread only.