### PR TITLE
Add missing include <limits> for std::numeric_limits

### DIFF
--- a/build_native.sh
+++ b/build_native.sh
@@ -11,4 +11,4 @@
 cp CMakeLists.txt.native CMakeLists.txt
 
 cmake CMakeLists.txt
-make prolog_bfs
+make prolog_bfs -j $(($(nproc) + 1)) 

--- a/build_wasm.sh
+++ b/build_wasm.sh
@@ -10,13 +10,13 @@ emcmake cmake CMakeLists.txt
 
 case $1 in
     "prod") echo "Running production built"
-            emmake make -j 12 prolog_bfs_prod
+            emmake make -j $(($(nproc) + 1)) prolog_bfs_prod
         ;;
     ""|"dev") echo "Running development built"
-            emmake make -j 12 prolog_bfs_dev
+            emmake make -j $(($(nproc) + 1)) prolog_bfs_dev
         ;;
     "test") echo "Running testing built"
-            emmake make -j 12 prolog_bfs_test
+            emmake make -j $(($(nproc) + 1)) prolog_bfs_test
         ;;
     *|"help") echo "Allowed options: prod, dev, test. e.g. build_wasm.sh prod"
 esac

--- a/src/wam/compiler/error/compiler_error.h
+++ b/src/wam/compiler/error/compiler_error.h
@@ -6,6 +6,7 @@
 #define PROLOG_BFS_COMPILER_ERROR_H
 
 #include <wam/data/source_code_info.h>
+#include <limits>
 #include "compiler_error_type.h"
 
 namespace compiler{


### PR DESCRIPTION
Fixes some file missing an include when compiling for native with gcc 10.1.0