### PR TITLE
Fix *continue search* button not working

### DIFF
--- a/web/assets/js/prolog_bfs/classes/TreeView.js
+++ b/web/assets/js/prolog_bfs/classes/TreeView.js
@@ -286,6 +286,7 @@ class TreeView {
                     }
                     // var_binding_node TO BE CONTINUED, we don't know its children yet
                     else {
+                        this.to_be_continued_node_ids.push(additional_node_counter);
                         nodes.push( { id: additional_node_counter,
                             label: "*continue search*",
                             color: { 


### PR DESCRIPTION
Under some circumstance, the continue search button in the tree view
did not react.